### PR TITLE
fix: add node polyfills plugin to rollup config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -78,7 +78,6 @@
         "rollup": "2.60.2",
         "rollup-plugin-dts": "^4.0.0",
         "rollup-plugin-node-polyfills": "^0.2.1",
-        "rollup-plugin-polyfill-node": "^0.8.0",
         "rollup-plugin-terser": "^7.0.2",
         "semantic-release": "^18.0.0",
         "sinon": "^12.0.0",
@@ -3217,20 +3216,6 @@
       },
       "peerDependencies": {
         "rollup": "^2.38.3"
-      }
-    },
-    "node_modules/@rollup/plugin-inject": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-inject/-/plugin-inject-4.0.4.tgz",
-      "integrity": "sha512-4pbcU4J/nS+zuHk+c+OL3WtmEQhqxlZ9uqfjQMQDOHOPld7PsCd8k5LWs8h5wjwJN7MgnAn768F2sDxEP4eNFQ==",
-      "dev": true,
-      "dependencies": {
-        "@rollup/pluginutils": "^3.1.0",
-        "estree-walker": "^2.0.1",
-        "magic-string": "^0.25.7"
-      },
-      "peerDependencies": {
-        "rollup": "^1.20.0 || ^2.0.0"
       }
     },
     "node_modules/@rollup/plugin-json": {
@@ -15640,18 +15625,6 @@
         "rollup-plugin-inject": "^3.0.0"
       }
     },
-    "node_modules/rollup-plugin-polyfill-node": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-polyfill-node/-/rollup-plugin-polyfill-node-0.8.0.tgz",
-      "integrity": "sha512-C4UeKedOmOBkB3FgR+z/v9kzRwV1Q/H8xWs1u1+CNe4XOV6hINfOrcO+TredKxYvopCmr+WKUSNsFUnD1RLHgQ==",
-      "dev": true,
-      "dependencies": {
-        "@rollup/plugin-inject": "^4.0.0"
-      },
-      "peerDependencies": {
-        "rollup": "^1.20.0 || ^2.0.0"
-      }
-    },
     "node_modules/rollup-plugin-terser": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/rollup-plugin-terser/-/rollup-plugin-terser-7.0.2.tgz",
@@ -20377,17 +20350,6 @@
         "is-reference": "^1.2.1",
         "magic-string": "^0.25.7",
         "resolve": "^1.17.0"
-      }
-    },
-    "@rollup/plugin-inject": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-inject/-/plugin-inject-4.0.4.tgz",
-      "integrity": "sha512-4pbcU4J/nS+zuHk+c+OL3WtmEQhqxlZ9uqfjQMQDOHOPld7PsCd8k5LWs8h5wjwJN7MgnAn768F2sDxEP4eNFQ==",
-      "dev": true,
-      "requires": {
-        "@rollup/pluginutils": "^3.1.0",
-        "estree-walker": "^2.0.1",
-        "magic-string": "^0.25.7"
       }
     },
     "@rollup/plugin-json": {
@@ -29972,15 +29934,6 @@
       "dev": true,
       "requires": {
         "rollup-plugin-inject": "^3.0.0"
-      }
-    },
-    "rollup-plugin-polyfill-node": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-polyfill-node/-/rollup-plugin-polyfill-node-0.8.0.tgz",
-      "integrity": "sha512-C4UeKedOmOBkB3FgR+z/v9kzRwV1Q/H8xWs1u1+CNe4XOV6hINfOrcO+TredKxYvopCmr+WKUSNsFUnD1RLHgQ==",
-      "dev": true,
-      "requires": {
-        "@rollup/plugin-inject": "^4.0.0"
       }
     },
     "rollup-plugin-terser": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -78,6 +78,7 @@
         "rollup": "2.60.2",
         "rollup-plugin-dts": "^4.0.0",
         "rollup-plugin-node-polyfills": "^0.2.1",
+        "rollup-plugin-polyfill-node": "^0.8.0",
         "rollup-plugin-terser": "^7.0.2",
         "semantic-release": "^18.0.0",
         "sinon": "^12.0.0",
@@ -3216,6 +3217,20 @@
       },
       "peerDependencies": {
         "rollup": "^2.38.3"
+      }
+    },
+    "node_modules/@rollup/plugin-inject": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-inject/-/plugin-inject-4.0.4.tgz",
+      "integrity": "sha512-4pbcU4J/nS+zuHk+c+OL3WtmEQhqxlZ9uqfjQMQDOHOPld7PsCd8k5LWs8h5wjwJN7MgnAn768F2sDxEP4eNFQ==",
+      "dev": true,
+      "dependencies": {
+        "@rollup/pluginutils": "^3.1.0",
+        "estree-walker": "^2.0.1",
+        "magic-string": "^0.25.7"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0 || ^2.0.0"
       }
     },
     "node_modules/@rollup/plugin-json": {
@@ -15625,6 +15640,18 @@
         "rollup-plugin-inject": "^3.0.0"
       }
     },
+    "node_modules/rollup-plugin-polyfill-node": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-polyfill-node/-/rollup-plugin-polyfill-node-0.8.0.tgz",
+      "integrity": "sha512-C4UeKedOmOBkB3FgR+z/v9kzRwV1Q/H8xWs1u1+CNe4XOV6hINfOrcO+TredKxYvopCmr+WKUSNsFUnD1RLHgQ==",
+      "dev": true,
+      "dependencies": {
+        "@rollup/plugin-inject": "^4.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0 || ^2.0.0"
+      }
+    },
     "node_modules/rollup-plugin-terser": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/rollup-plugin-terser/-/rollup-plugin-terser-7.0.2.tgz",
@@ -20350,6 +20377,17 @@
         "is-reference": "^1.2.1",
         "magic-string": "^0.25.7",
         "resolve": "^1.17.0"
+      }
+    },
+    "@rollup/plugin-inject": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-inject/-/plugin-inject-4.0.4.tgz",
+      "integrity": "sha512-4pbcU4J/nS+zuHk+c+OL3WtmEQhqxlZ9uqfjQMQDOHOPld7PsCd8k5LWs8h5wjwJN7MgnAn768F2sDxEP4eNFQ==",
+      "dev": true,
+      "requires": {
+        "@rollup/pluginutils": "^3.1.0",
+        "estree-walker": "^2.0.1",
+        "magic-string": "^0.25.7"
       }
     },
     "@rollup/plugin-json": {
@@ -29934,6 +29972,15 @@
       "dev": true,
       "requires": {
         "rollup-plugin-inject": "^3.0.0"
+      }
+    },
+    "rollup-plugin-polyfill-node": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-polyfill-node/-/rollup-plugin-polyfill-node-0.8.0.tgz",
+      "integrity": "sha512-C4UeKedOmOBkB3FgR+z/v9kzRwV1Q/H8xWs1u1+CNe4XOV6hINfOrcO+TredKxYvopCmr+WKUSNsFUnD1RLHgQ==",
+      "dev": true,
+      "requires": {
+        "@rollup/plugin-inject": "^4.0.0"
       }
     },
     "rollup-plugin-terser": {

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
   "dependencies": {
     "@babel/runtime": "^7.12.5",
     "@ethersproject/sha2": "^5.5.0",
+    "@exodus/json-rpc": "^1.6.0",
     "@solana/buffer-layout": "^3.0.0",
     "bn.js": "^5.0.0",
     "borsh": "^0.4.0",
@@ -68,7 +69,6 @@
     "buffer": "6.0.1",
     "create-hash": "~1.1.3",
     "cross-fetch": "^3.1.4",
-    "@exodus/json-rpc": "^1.6.0",
     "js-sha3": "^0.8.0",
     "rpc-websockets": "^7.4.2",
     "secp256k1": "^4.0.2",
@@ -128,6 +128,7 @@
     "rollup": "2.60.2",
     "rollup-plugin-dts": "^4.0.0",
     "rollup-plugin-node-polyfills": "^0.2.1",
+    "rollup-plugin-polyfill-node": "^0.8.0",
     "rollup-plugin-terser": "^7.0.2",
     "semantic-release": "^18.0.0",
     "sinon": "^12.0.0",

--- a/package.json
+++ b/package.json
@@ -128,7 +128,6 @@
     "rollup": "2.60.2",
     "rollup-plugin-dts": "^4.0.0",
     "rollup-plugin-node-polyfills": "^0.2.1",
-    "rollup-plugin-polyfill-node": "^0.8.0",
     "rollup-plugin-terser": "^7.0.2",
     "semantic-release": "^18.0.0",
     "sinon": "^12.0.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -17,9 +17,7 @@ function generateConfig(configType, format) {
     input: 'src/index.ts',
     plugins: [
       commonjs(),
-      nodePolyfills({
-        include: ['events']
-      }),
+      nodePolyfills(),
       nodeResolve({
         browser,
         dedupe: ['bn.js', 'buffer'],

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -4,7 +4,7 @@ import json from '@rollup/plugin-json';
 import nodeResolve from '@rollup/plugin-node-resolve';
 import replace from '@rollup/plugin-replace';
 import {terser} from 'rollup-plugin-terser';
-import nodePolyfills from 'rollup-plugin-polyfill-node';
+import nodePolyfills from 'rollup-plugin-node-polyfills';
 
 const env = process.env.NODE_ENV;
 const extensions = ['.js', '.ts'];

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -4,6 +4,7 @@ import json from '@rollup/plugin-json';
 import nodeResolve from '@rollup/plugin-node-resolve';
 import replace from '@rollup/plugin-replace';
 import {terser} from 'rollup-plugin-terser';
+import nodePolyfills from 'rollup-plugin-polyfill-node';
 
 const env = process.env.NODE_ENV;
 const extensions = ['.js', '.ts'];
@@ -16,6 +17,9 @@ function generateConfig(configType, format) {
     input: 'src/index.ts',
     plugins: [
       commonjs(),
+      nodePolyfills({
+        include: ['events']
+      }),
       nodeResolve({
         browser,
         dedupe: ['bn.js', 'buffer'],


### PR DESCRIPTION
On `npm run build` in the base branch, the following errors are emitted:

```
src/index.ts → lib/index.cjs.js, lib/index.esm.js...
created lib/index.cjs.js, lib/index.esm.js in 905ms

src/index.ts → lib/index.browser.esm.js...
(!) Unresolved dependencies
https://rollupjs.org/guide/en/#warning-treating-module-as-external-dependency
events (imported by src/connection.ts, events?commonjs-external)
stream (imported by stream?commonjs-external)
created lib/index.browser.esm.js in 703ms

src/index.ts → lib/index.iife.js, lib/index.iife.min.js...
(!) Missing shims for Node.js built-ins
Creating a browser bundle that depends on "events" and "stream". You might need to include https://github.com/snowpackjs/rollup-plugin-polyfill-node
(!) Missing shims for Node.js built-ins
Creating a browser bundle that depends on "events" and "stream". You might need to include https://github.com/snowpackjs/rollup-plugin-polyfill-node
(!) Missing global variable names
Use output.globals to specify browser global variable names corresponding to external modules
events (guessing 'require$$0$1')
stream (guessing 'require$$1')
events (guessing 'require$$0$1')
stream (guessing 'require$$1')
(!) Unresolved dependencies
https://rollupjs.org/guide/en/#warning-treating-module-as-external-dependency
events (imported by src/connection.ts, events?commonjs-external)
stream (imported by stream?commonjs-external)
created lib/index.iife.js, lib/index.iife.min.js in 2.2s
```

Output in the terminal suggests to install [rollup-plugin-polyfill-node](https://www.npmjs.com/package/rollup-plugin-polyfill-node). The npm package has been installed and configured in the rollup config to include `events` polyfill.

Parent PR: https://github.com/ExodusMovement/solana-web3.js/pull/2