### PR TITLE
chore: update build process

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,9 @@
     "maintained node versions"
   ],
   "files": [
-    "/lib",
+    "/lib/index.browser.esm.js",
+    "/lib/index.browser.esm.js.map",
+    "/lib/index.d.ts",
     "/module.flow.js"
   ],
   "scripts": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -81,12 +81,13 @@ function generateConfig(configType, format) {
           // Prevent dependencies from being bundled
           config.external = [
             /@babel\/runtime/,
+            '@exodus/json-rpc',
             '@solana/buffer-layout',
             'bn.js',
             'borsh',
             'bs58',
             'buffer',
-            'crypto-hash',
+            'create-hash',
             'http',
             'https',
             'jayson/lib/client/browser',


### PR DESCRIPTION
This PR updates the rollup config to exclude `@exodus/json-rpc` and `create-hash` from getting bundled. Also, the `files` prop in package.json is updated to include browser-related bundle and type declaration files.

PS. `crypto-hash` was replaced with `create-hash` in earlier commits. 