### PR TITLE
fix: remove create-hash from rollup config.external

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -89,7 +89,6 @@ function generateConfig(configType, format) {
             'borsh',
             'bs58',
             'buffer',
-            'create-hash',
             'http',
             'https',
             'js-sha3',

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -92,7 +92,6 @@ function generateConfig(configType, format) {
             'create-hash',
             'http',
             'https',
-            'jayson/lib/client/browser',
             'js-sha3',
             'rpc-websockets',
             'secp256k1',


### PR DESCRIPTION
This PR removes the package `create-hash` from the rollup `config.external` option that prevents dependencies from getting bundled. 

Without this change, a bunch of errors related to `stream`, and `events` are thrown from the `create-hash`'s dependencies. 

Parent PR: https://github.com/ExodusMovement/solana-web3.js/pull/6