### PR TITLE
fix: use fetch from exodus/fetch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,17 @@
 {
-  "name": "@solana/web3.js",
-  "version": "0.0.0-development",
+  "name": "@exodus/solana-web3.js",
+  "version": "1.31.0-exodus.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "@solana/web3.js",
-      "version": "0.0.0-development",
+      "name": "@exodus/solana-web3.js",
+      "version": "1.31.0-exodus.3",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.12.5",
         "@ethersproject/sha2": "^5.5.0",
+        "@exodus/fetch": "^1.2.1",
         "@solana/buffer-layout": "^3.0.0",
         "bn.js": "^5.0.0",
         "borsh": "^0.4.0",
@@ -2637,6 +2638,24 @@
         "hash.js": "1.1.7"
       }
     },
+    "node_modules/@exodus/fetch": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@exodus/fetch/-/fetch-1.2.1.tgz",
+      "integrity": "sha512-VdDOychePt+d5L4loB3CDW32Q3AI9cXNcsOUBdc8kepTVJ9I6z7TbFuKvotd1jIgQY4FNV5AQGqonZZpRyDvRg==",
+      "dependencies": {
+        "fetchival": "^0.3.3",
+        "node-fetch": "^2.6.0",
+        "ws": "^6.1.0"
+      }
+    },
+    "node_modules/@exodus/fetch/node_modules/ws": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.2.tgz",
+      "integrity": "sha512-zmhltoSR8u1cnDsD43TX59mzoMZsLKqUweyYBAIvTngR3shc0W6aOZylZmq/7hqyVxPdi+5Ud2QInblgyE72fw==",
+      "dependencies": {
+        "async-limiter": "~1.0.0"
+      }
+    },
     "node_modules/@graphql-tools/schema": {
       "version": "7.1.5",
       "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-7.1.5.tgz",
@@ -4807,6 +4826,11 @@
       "dependencies": {
         "lodash": "^4.17.14"
       }
+    },
+    "node_modules/async-limiter": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
+      "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ=="
     },
     "node_modules/axios": {
       "version": "0.21.1",
@@ -7683,6 +7707,11 @@
       "dependencies": {
         "node-fetch": "~2.6.1"
       }
+    },
+    "node_modules/fetchival": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/fetchival/-/fetchival-0.3.3.tgz",
+      "integrity": "sha512-4C2NlX2yDiOD81/ZOtpuBsIq+tdSqPXD4pp5ZNiLDBJckoquvjJNzPEtqj4NjXVtsP1GAWPcR9ebLNSWvevUoA=="
     },
     "node_modules/figures": {
       "version": "3.2.0",
@@ -19904,6 +19933,26 @@
         "hash.js": "1.1.7"
       }
     },
+    "@exodus/fetch": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@exodus/fetch/-/fetch-1.2.1.tgz",
+      "integrity": "sha512-VdDOychePt+d5L4loB3CDW32Q3AI9cXNcsOUBdc8kepTVJ9I6z7TbFuKvotd1jIgQY4FNV5AQGqonZZpRyDvRg==",
+      "requires": {
+        "fetchival": "^0.3.3",
+        "node-fetch": "^2.6.0",
+        "ws": "^6.1.0"
+      },
+      "dependencies": {
+        "ws": {
+          "version": "6.2.2",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.2.tgz",
+          "integrity": "sha512-zmhltoSR8u1cnDsD43TX59mzoMZsLKqUweyYBAIvTngR3shc0W6aOZylZmq/7hqyVxPdi+5Ud2QInblgyE72fw==",
+          "requires": {
+            "async-limiter": "~1.0.0"
+          }
+        }
+      }
+    },
     "@graphql-tools/schema": {
       "version": "7.1.5",
       "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-7.1.5.tgz",
@@ -21629,6 +21678,11 @@
       "requires": {
         "lodash": "^4.17.14"
       }
+    },
+    "async-limiter": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
+      "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ=="
     },
     "axios": {
       "version": "0.21.1",
@@ -23949,6 +24003,11 @@
       "requires": {
         "node-fetch": "~2.6.1"
       }
+    },
+    "fetchival": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/fetchival/-/fetchival-0.3.3.tgz",
+      "integrity": "sha512-4C2NlX2yDiOD81/ZOtpuBsIq+tdSqPXD4pp5ZNiLDBJckoquvjJNzPEtqj4NjXVtsP1GAWPcR9ebLNSWvevUoA=="
     },
     "figures": {
       "version": "3.2.0",

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
   "dependencies": {
     "@babel/runtime": "^7.12.5",
     "@ethersproject/sha2": "^5.5.0",
+    "@exodus/fetch": "^1.2.1",
     "@solana/buffer-layout": "^3.0.0",
     "bn.js": "^5.0.0",
     "borsh": "^0.4.0",

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -1,6 +1,6 @@
 import bs58 from 'bs58';
 import {Buffer} from 'buffer';
-import fetch from 'cross-fetch';
+import { fetch } from '@exodus/fetch';
 import type {Response} from 'cross-fetch';
 import {
   type as pick,


### PR DESCRIPTION
We don't want to bundle `cross-fetch`, and our wrapper handles that nicely.

`cross-fetch` still remains for typings, that is insignificant and goes away in build.