### PR TITLE
fix: make esm default

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,10 +20,9 @@
     "access": "public"
   },
   "browser": {
-    "./lib/index.cjs.js": "./lib/index.browser.esm.js",
     "./lib/index.esm.js": "./lib/index.browser.esm.js"
   },
-  "main": "lib/index.cjs.js",
+  "main": "lib/index.esm.js",
   "types": "lib/index.d.ts",
   "browserslist": [
     "defaults",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -249,7 +249,7 @@ function generateConfig(configType, format) {
 }
 
 export default [
-  generateConfig('node'),
+  // generateConfig('node'),
   generateConfig('browser', 'esm'),
   // generateConfig('browser', 'iife'),
   // generateConfig('react-native'),


### PR DESCRIPTION
This PR removes CJS support - only ESM now.
