### PR TITLE
chore: export layout pkg

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ export * from './validator-info';
 export * from './vote-account';
 export * from './sysvar';
 export * from './utils';
+export * from './layout';
 
 /**
  * There are 1-billion lamports in one SOL


### PR DESCRIPTION
I added an export to `./layout` that we will need in order to replace our solana [vendor](https://github.com/ExodusMovement/assets/tree/main/solana/solana-lib/src/vendor) folder in `assets` and start using this fork.

Related with: https://github.com/ExodusMovement/assets/issues/2019