### PR TITLE
fix: avoid wild card import

### DIFF
--- a/src/utils/secp256k1.ts
+++ b/src/utils/secp256k1.ts
@@ -1,6 +1,6 @@
 import * as secp256k1 from '@noble/secp256k1';
 // @ts-ignore
-import * as hmac from 'create-hmac';
+import hmac from 'create-hmac';
 
 // Supply a synchronous hashing algorithm to make this
 // library interoperable with the synchronous APIs in web3.js.


### PR DESCRIPTION
Removes a wild card import because `vite` bundler throws an error:
`../../node_modules/@exodus/solana-web3.js/lib/index.browser.esm.js (9048:12) Cannot call a namespace ("hmac").`