### PR TITLE
fix: use default signatures if empty

### DIFF
--- a/src/transaction/versioned.ts
+++ b/src/transaction/versioned.ts
@@ -23,7 +23,7 @@ export class VersionedTransaction {
   }
 
   constructor(message: VersionedMessage, signatures?: Array<Uint8Array>) {
-    if (signatures !== undefined) {
+    if (signatures !== undefined  && signatures.length !==  0) {
       assert(
         signatures.length === message.header.numRequiredSignatures,
         'Expected signatures length to be equal to the number of required signatures',


### PR DESCRIPTION
This PR fixes an issue where the transaction deserialization will initialize an empty array with length 0 and doesn't trigger the default empty signature creation.
