### PR TITLE
chore: bump to published version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@exodus/solana-web3.js",
-  "version": "1.63.1-exodus.9-rc3",
+  "version": "1.63.1-exodus.9-rc4",
   "description": "Solana Javascript API",
   "keywords": [
     "api",


### PR DESCRIPTION
Bumps to latest published version 1.63.1-exodus.9-rc4.


<img width="511" alt="image" src="https://github.com/user-attachments/assets/88e8a121-af32-4654-998d-43d3ef3aeeaf">
